### PR TITLE
Add status counts to OneMeasurementHdrHistogram.getSummary()

### DIFF
--- a/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
@@ -79,4 +79,12 @@ public abstract class OneMeasurement {
       exporter.write(getName(), "Return=" + entry.getKey().getName(), entry.getValue().get());
     }
   }
+
+  public final String getStatusCounts() {
+    StringBuilder buckets = new StringBuilder();
+    for (Map.Entry<Status, AtomicInteger> entry : returncodes.entrySet()) {
+      buckets.append(", Return(" + entry.getKey().getName() + ")=" + entry.getValue().get());
+    }
+    return buckets.toString();
+  }
 }

--- a/core/src/main/java/site/ycsb/measurements/OneMeasurementHdrHistogram.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurementHdrHistogram.java
@@ -142,26 +142,31 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
 
   /**
    * This is called periodically from the StatusThread. There's a single
-   * StatusThread per Client process. We optionally serialize the interval to
-   * log on this opportunity.
+   * StatusThread per Client process. We optionally serialize the interval to log
+   * on this opportunity.
+   * 
+   * @throws IOException
    *
    * @see site.ycsb.measurements.OneMeasurement#getSummary()
    */
   @Override
   public String getSummary() {
+
     Histogram intervalHistogram = getIntervalHistogramAndAccumulate();
     // we use the summary interval as the histogram file interval.
     if (histogramLogWriter != null) {
       histogramLogWriter.outputIntervalHistogram(intervalHistogram);
     }
 
+    String buckets = getStatusCounts();
+    
     DecimalFormat d = new DecimalFormat("#.##");
     return "[" + getName() + ": Count=" + intervalHistogram.getTotalCount() + ", Max="
         + intervalHistogram.getMaxValue() + ", Min=" + intervalHistogram.getMinValue() + ", Avg="
         + d.format(intervalHistogram.getMean()) + ", 90=" + d.format(intervalHistogram.getValueAtPercentile(90))
         + ", 99=" + d.format(intervalHistogram.getValueAtPercentile(99)) + ", 99.9="
         + d.format(intervalHistogram.getValueAtPercentile(99.9)) + ", 99.99="
-        + d.format(intervalHistogram.getValueAtPercentile(99.99)) + "]";
+        + d.format(intervalHistogram.getValueAtPercentile(99.99)) + buckets +"]";
   }
 
   private Histogram getIntervalHistogramAndAccumulate() {


### PR DESCRIPTION
the stauts print is now reporting also the buckets of status on each operation
so we could find VERIFY errors while the run is happening, and not only at the end

would enable summary print like the below, which show datainegrity failure as example:
```
[VERIFY: Count=1807, Max=11567, Min=0, Avg=110.3, 90=399, 99=658, 99.9=1133, 99.99=11567, Return(OK)=633, Return(ERROR)=1174]
```