### PR TITLE
[Dynamodb] add support for updating TTL

### DIFF
--- a/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
@@ -268,6 +268,11 @@ public class DynamoDBClient extends DB {
       attributes.put(val.getKey(), new AttributeValueUpdate().withValue(v).withAction("PUT"));
     }
 
+    if (null != this.ttlKeyName) {
+      AttributeValue v = new AttributeValue(String.valueOf((System.currentTimeMillis() / 1000L) + this.ttlDuration));
+      attributes.put(this.ttlKeyName, new AttributeValueUpdate().withValue(v).withAction("PUT"));
+    }
+
     UpdateItemRequest req = new UpdateItemRequest(table, createPrimaryKey(key), attributes);
 
     try {


### PR DESCRIPTION
Works exactly as in the inserts
that was introduced in 9794fbe7e9675d08c2013447d6e00088afc49af0

example of usage:
```
./bin/ycsb run dynamodb -P workloads/workloada  -p dynamodb.ttlKey=ttl -p dynamodb.ttlDuration=30  -P dynamodb.properties
```