### PR TITLE
feature(ci): add GH Actions CI for building testing and releasing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build/
+.idea/
+.github/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: "Build"
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: "Version of the release"
+      java:
+        required: false
+        description: "Java version"
+        type: string
+        default: "21"
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: "Version of the release"
+        type: string
+      java:
+        required: false
+        description: "Java version"
+        type: string
+        default: "21"
+jobs:
+  build:
+    name: Build ${{ inputs.version }} for Java ${{ inputs.java }}
+    strategy:
+      matrix:
+        os: ["ubuntu-24.04"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ inputs.java }}
+
+      - name: Install Deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm dpkg-dev devscripts debhelper dh-make build-essential maven
+
+      - name: Artifacts
+        run: |
+          ./scripts/package.sh ${{ inputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ycsb-java${{ inputs.java }}
+          path: |
+            scylla-ycsb-${{ inputs.version }}-java${{ inputs.java }}.tar.gz

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -1,0 +1,22 @@
+name: Update Docker Hub Description
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+jobs:
+  description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: scylladb/ycsb
+          short-description: ${{ github.event.repository.description }}
+          enable-url-completion: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,96 @@
+name: "Build Docker Image"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        default: ""
+        required: true
+        description: ""
+        type: string
+      java_version:
+        default: "21"
+        required: false
+        description: ""
+        type: string
+      docker_target:
+        default: production
+        required: false
+        description: ""
+        type: string
+      platforms:
+        default: linux/amd64,linux/arm64
+        required: false
+        description: ""
+        type: string
+      image:
+        default: "scylladb/ycsb"
+        required: false
+        description: ""
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        default: ""
+        required: true
+        type: string
+      java_version:
+        default: "8"
+        required: false
+        description: ""
+        type: string
+      docker_target:
+        default: production
+        required: false
+        type: string
+      platforms:
+        default: linux/amd64,linux/arm64
+        required: false
+        type: string
+      image:
+        default: "scylladb/ycsb"
+        required: false
+        type: string
+    secrets:
+      REGISTRY:
+        required: true
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+jobs:
+  build:
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDX_GIT_INFO: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push API
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          pull: true
+          platforms: ${{ inputs.platforms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ inputs.image }}:latest
+            ${{ inputs.image }}:${{ inputs.version }}
+          build-args: |
+            INPUT_JAVA_VERSION=${{ inputs.java_version }}
+            VERSION=${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: "Release"
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tag:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version_tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Get Tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: olegtarasov/get-tag@v2.1.4
+        id: version_tag
+        with:
+          tagRegex: "v(.*)"
+  docker:
+    needs: ["tag"]
+    uses: "./.github/workflows/docker.yml"
+    with:
+      version: "${{ needs.tag.outputs.version }}"
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      REGISTRY: ${{ secrets.REGISTRY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  build:
+    needs: ["tag"]
+    uses: "./.github/workflows/build.yml"
+    strategy:
+      matrix:
+        java: ["8", "21"]
+    with:
+      version: "${{ needs.tag.outputs.version }}"
+      java: "${{ matrix.java }}"
+  release:
+    needs: ["tag", "docker", "build"]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ycsb-java8
+      - uses: actions/download-artifact@v4
+        with:
+          name: ycsb-java21
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        id: release
+        with:
+          make_latest: true
+          name: "v${{ needs.tag.outputs.version }}"
+          tag_name: "v${{ needs.tag.outputs.version }}"
+          generate_release_notes: true
+          append_body: true
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: |
+             scylla-ycsb-${{ needs.tag.outputs.version }}-java8.tar.gz
+             scylla-ycsb-${{ needs.tag.outputs.version }}-java21.tar.gz
+      - name: "Generate release changelog"
+        uses: heinrichreimer/action-github-changelog-generator@v2.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          author: true
+          releaseUrl: ${{ steps.release.outputs.url }}
+          issues: false
+          pullRequests: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: "Test"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  packaging:
+    strategy:
+      fail-fast: true
+      matrix:
+        java: ["8", "11", "21"]
+    uses: "./.github/workflows/build.yml"
+    with:
+      version: "1.0.0"
+      java: "${{ matrix.java }}"
+  tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        java: ["8", "11", "21"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "${{ matrix.java }}"
+      - name: Install Deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y maven
+      - name: Run Tests
+        run: mvn -ff -pl site.ycsb:scylla-binding,site.ycsb:dynamodb-binding -am test -Djava.source="${{ matrix.java }}" -Djava.target="${{ matrix.java }}" -DskipTests=false

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ output*
 # ignore standard Mac OS X files/dirs
 .DS_Store
 /differentbin/
+build/
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+ARG VERSION
+ARG INPUT_JAVA_VERSION=8
+FROM eclipse-temurin:${INPUT_JAVA_VERSION}-jdk-noble AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN apt-get update && apt-get install -y maven \
+    && ./scripts/package.sh ${VERSION} ${INPUT_JAVA_VERSION}
+
+FROM eclipse-temurin:${INPUT_JAVA_VERSION}-jre-noble AS production
+
+LABEL org.opencontainers.image.source="https://github.com/scylladb/YCSB"
+LABEL org.opencontainers.image.title="ScyllaDB YCSB"
+
+ENV YCSB_HOME="/usr/local/share/scylla-ycsb"
+ENV PATH="$PATH:$YCSB_HOME/bin"
+ENV LD_LIBRARY_PATH="/lib/x86_64-linux-gnu:/usr/local/lib:/usr/lib:/lib:/lib64:/usr/local/lib/x86_64-linux-gnu"
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV TZ="UTC"
+
+WORKDIR /
+
+RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime \
+    && echo "$TZ" > /etc/timezone \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get purge -y \
+    gcc make g++ apt-transport-https \
+    autoconf bzip2 cpp libasan8 m4 libtirpc3 libtsan2 libubsan1 build-essential \
+    pkg-config pkgconf pkgconf-bin build-essential \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN echo 'networkaddress.cache.ttl=0' >> $JAVA_HOME/lib/security/java.security
+RUN echo 'networkaddress.cache.negative.ttl=0' >> $JAVA_HOME/lib/security/java.security
+COPY --from=build /app/build ${YCSB_HOME}
+
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENTRYPOINT ["ycsb.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,8 @@ LICENSE file.
   <properties>
     <maven.assembly.version>2.5.5</maven.assembly.version>
     <maven.dependency.version>2.10</maven.dependency.version>
+    <java.source>1.8</java.source>
+    <java.target>1.8</java.target>
 
     <!-- datastore binding versions, lex sorted -->
     <accumulo.1.9.version>1.9.3</accumulo.1.9.version>
@@ -243,10 +245,10 @@ LICENSE file.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.11.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${java.source}</source>
+          <target>${java.target}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION="${1:-"0.18.0-SNAPSHOT"}"
+JAVA="${2:-11}"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+rm -rf build
+
+mvn versions:set -DnewVersion="$VERSION"
+mvn versions:commit
+
+mvn -ff \
+  -pl site.ycsb:scylla-binding,site.ycsb:dynamodb-binding \
+  -am clean package \
+  -Djava.source="$JAVA" \
+  -Djava.target="$JAVA" \
+  -DskipTests
+
+mkdir -p build/conf
+
+tar -xvf "scylla/target/ycsb-scylla-binding-$VERSION.tar.gz" -C build --strip-components=1
+tar -xvf "dynamodb/target/ycsb-dynamodb-binding-$VERSION.tar.gz" -C build --strip-components=1
+
+cp conf/* build/conf/
+
+tar -zcvf "scylla-ycsb-$VERSION-java$JAVA.tar.gz" build


### PR DESCRIPTION
- Pipelines for building testing and releasing

This release CI differs from official releases, it just builds YCSB with Scylla Support and everything else is ignored (this is what we need for testing). Running the tools remains the same, but breaks if tool is tried with different "driver" as this .jar file is not in the final distribution.

Closes #7