### PR TITLE
Add tags and additional log output

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,11 @@ LICENSE file.
       <artifactId>HdrHistogram</artifactId>
       <version>2.1.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.10</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Add tagging to hdr histogram output.
Add `hdrhistogram.tag` option, which enables tagging. Add logging around hdr histogram object construction.