### PR TITLE
fix(core): preserve property file values with unresolved ${} placeholders

### DIFF
--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -595,9 +595,7 @@ public final class Client {
       if (value.startsWith("${")) {
         String key = value.substring(2, value.length() - 1);
         String replacement = System.getProperty(key);
-        if (replacement != null) {
-          into.setProperty(prop, replacement);
-        }
+        into.setProperty(prop, replacement != null ? replacement : value);
       } else {
         into.setProperty(prop, value);
       }


### PR DESCRIPTION
## Summary

- Properties loaded via `-P` whose values start with `${KEY}` were silently dropped when no JVM system property `-DKEY=...` was set
- This broke DynamoDB (and any other binding) connection when property files use `${...}` placeholder syntax — properties like `dynamodb.endpoint`, `dynamodb.region`, credentials etc. simply vanished
- Root cause introduced in v1.3.0 by PR #30 (`loadPropertyFile` method in `Client.java:595-600`)
- Fix: fall back to original literal value when system property doesn't resolve, restoring v1.2.0 behavior

## Root cause

```java
// BEFORE (broken): unresolved ${KEY} → property silently dropped
if (replacement != null) {
    into.setProperty(prop, replacement);
}

// AFTER (fixed): unresolved ${KEY} → keep original value
into.setProperty(prop, replacement != null ? replacement : value);
```

## Test plan

- [ ] Run DynamoDB binding with a properties file containing literal `${...}` values — verify they are no longer dropped
- [ ] Run DynamoDB binding with a properties file containing `${KEY}` where `-DKEY=value` is set — verify expansion still works
- [ ] Verify `--version` command still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)