### PR TITLE
fix(core): stop workload after consecutive DB errors to prevent disk fill

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -347,6 +347,13 @@ public class CoreWorkload extends Workload {
   public static final String INSERTION_RETRY_INTERVAL_DEFAULT = "3";
 
   /**
+   * Maximum number of consecutive errors per thread before the workload is stopped.
+   * Set to 0 to disable (never stop on errors). Default is 100.
+   */
+  public static final String MAX_CONSECUTIVE_ERRORS_PROPERTY = "max_consecutive_errors";
+  public static final String MAX_CONSECUTIVE_ERRORS_DEFAULT = "10";
+
+  /**
    * Field name prefix.
    */
   public static final String FIELD_NAME_PREFIX = "fieldnameprefix";
@@ -368,6 +375,8 @@ public class CoreWorkload extends Workload {
   protected int zeropadding;
   protected int insertionRetryLimit;
   protected int insertionRetryInterval;
+  private int maxConsecutiveErrors;
+  private final ThreadLocal<Integer> consecutiveErrors = ThreadLocal.withInitial(() -> 0);
 
   private Measurements measurements = Measurements.getMeasurements();
 
@@ -545,6 +554,8 @@ public class CoreWorkload extends Workload {
         INSERTION_RETRY_LIMIT, INSERTION_RETRY_LIMIT_DEFAULT));
     insertionRetryInterval = Integer.parseInt(p.getProperty(
         INSERTION_RETRY_INTERVAL, INSERTION_RETRY_INTERVAL_DEFAULT));
+    maxConsecutiveErrors = Integer.parseInt(p.getProperty(
+        MAX_CONSECUTIVE_ERRORS_PROPERTY, MAX_CONSECUTIVE_ERRORS_DEFAULT));
   }
 
   /**
@@ -659,21 +670,37 @@ public class CoreWorkload extends Workload {
       return false;
     }
 
+    Status status;
     switch (operation) {
     case "READ":
-      doTransactionRead(db);
+      status = doTransactionRead(db);
       break;
     case "UPDATE":
-      doTransactionUpdate(db);
+      status = doTransactionUpdate(db);
       break;
     case "INSERT":
-      doTransactionInsert(db);
+      status = doTransactionInsert(db);
       break;
     case "SCAN":
-      doTransactionScan(db);
+      status = doTransactionScan(db);
       break;
     default:
-      doTransactionReadModifyWrite(db);
+      status = doTransactionReadModifyWrite(db);
+    }
+
+    if (maxConsecutiveErrors > 0) {
+      if (status == null || !status.isOk()) {
+        int errors = consecutiveErrors.get() + 1;
+        consecutiveErrors.set(errors);
+        if (errors >= maxConsecutiveErrors) {
+          System.err.println("Thread stopping workload after " + errors +
+              " consecutive errors. Last status: " + status);
+          requestStopBecauseOfError();
+          return false;
+        }
+      } else {
+        consecutiveErrors.set(0);
+      }
     }
 
     return true;
@@ -719,7 +746,7 @@ public class CoreWorkload extends Workload {
     return keynum;
   }
 
-  public void doTransactionRead(DB db) {
+  public Status doTransactionRead(DB db) {
     // choose a random key
     long keynum = nextKeynum();
 
@@ -739,14 +766,16 @@ public class CoreWorkload extends Workload {
     }
 
     HashMap<String, ByteIterator> cells = new HashMap<String, ByteIterator>();
-    db.read(table, keyname, fields, cells);
+    Status status = db.read(table, keyname, fields, cells);
 
     if (dataintegrity) {
       verifyRow(keyname, cells);
     }
+
+    return status;
   }
 
-  public void doTransactionReadModifyWrite(DB db) {
+  public Status doTransactionReadModifyWrite(DB db) {
     // choose a random key
     long keynum = nextKeynum();
 
@@ -779,10 +808,8 @@ public class CoreWorkload extends Workload {
 
     long ist = measurements.getIntendedStartTimeNs();
     long st = System.nanoTime();
-    db.read(table, keyname, fields, cells);
-
-    db.update(table, keyname, values);
-
+    Status readStatus = db.read(table, keyname, fields, cells);
+    Status updateStatus = db.update(table, keyname, values);
     long en = System.nanoTime();
 
     if (dataintegrity) {
@@ -791,9 +818,14 @@ public class CoreWorkload extends Workload {
 
     measurements.measure("READ-MODIFY-WRITE", (long) ((en - st) / 1000));
     measurements.measureIntended("READ-MODIFY-WRITE", (long) ((en - ist) / 1000));
+
+    if (readStatus != null && !readStatus.isOk()) {
+      return readStatus;
+    }
+    return updateStatus;
   }
 
-  public void doTransactionScan(DB db) {
+  public Status doTransactionScan(DB db) {
     // choose a random key
     long keynum = nextKeynum();
 
@@ -812,10 +844,10 @@ public class CoreWorkload extends Workload {
       fields.add(fieldname);
     }
 
-    db.scan(table, startkeyname, len, fields, new Vector<HashMap<String, ByteIterator>>());
+    return db.scan(table, startkeyname, len, fields, new Vector<HashMap<String, ByteIterator>>());
   }
 
-  public void doTransactionUpdate(DB db) {
+  public Status doTransactionUpdate(DB db) {
     // choose a random key
     long keynum = nextKeynum();
 
@@ -831,10 +863,10 @@ public class CoreWorkload extends Workload {
       values = buildSingleValue(keyname);
     }
 
-    db.update(table, keyname, values);
+    return db.update(table, keyname, values);
   }
 
-  public void doTransactionInsert(DB db) {
+  public Status doTransactionInsert(DB db) {
     // choose the next key
     long keynum = transactioninsertkeysequence.nextValue();
 
@@ -842,7 +874,7 @@ public class CoreWorkload extends Workload {
       String dbkey = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
       HashMap<String, ByteIterator> values = buildValues(dbkey);
-      db.insert(table, dbkey, values);
+      return db.insert(table, dbkey, values);
     } finally {
       transactioninsertkeysequence.acknowledge(keynum);
     }

--- a/core/src/main/java/site/ycsb/workloads/RestWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/RestWorkload.java
@@ -20,6 +20,7 @@ package site.ycsb.workloads;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.RandomByteIterator;
+import site.ycsb.Status;
 import site.ycsb.WorkloadException;
 import site.ycsb.generator.*;
 
@@ -278,29 +279,29 @@ public class RestWorkload extends CoreWorkload {
   }
 
   @Override
-  public void doTransactionRead(DB db) {
+  public Status doTransactionRead(DB db) {
     HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    db.read(null, getNextURL(1), null, result);
+    return db.read(null, getNextURL(1), null, result);
   }
 
   @Override
-  public void doTransactionInsert(DB db) {
+  public Status doTransactionInsert(DB db) {
     HashMap<String, ByteIterator> value = new HashMap<String, ByteIterator>();
     // Create random bytes of insert data with a specific size.
     value.put("data", new RandomByteIterator(fieldlengthgenerator.nextValue().longValue()));
-    db.insert(null, getNextURL(2), value);
+    return db.insert(null, getNextURL(2), value);
   }
 
-  public void doTransactionDelete(DB db) {
-    db.delete(null, getNextURL(3));
+  public Status doTransactionDelete(DB db) {
+    return db.delete(null, getNextURL(3));
   }
 
   @Override
-  public void doTransactionUpdate(DB db) {
+  public Status doTransactionUpdate(DB db) {
     HashMap<String, ByteIterator> value = new HashMap<String, ByteIterator>();
     // Create random bytes of update data with a specific size.
     value.put("data", new RandomByteIterator(fieldlengthgenerator.nextValue().longValue()));
-    db.update(null, getNextURL(4), value);
+    return db.update(null, getNextURL(4), value);
   }
 
 }

--- a/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
@@ -61,6 +61,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.io.IOException;
 import java.io.FileInputStream;
 import java.util.*;
@@ -741,7 +742,12 @@ public final class DynamoDBClient extends DB {
       return Status.ERROR;
     }
     if (cause instanceof SdkClientException sdkException) {
-      LOGGER.error(sdkException);
+      if (sdkException.getCause() instanceof UnknownHostException uhe) {
+        LOGGER.error("DNS resolution failed for '" + uhe.getMessage() +
+            "': check endpoint configuration and DNS availability");
+      } else {
+        LOGGER.error(sdkException);
+      }
       return CLIENT_ERROR;
     }
     LOGGER.error(cause);

--- a/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
@@ -247,7 +247,9 @@ public final class DynamoDBClient extends DB {
 
     // Only configure custom HTTP client if we need to customize it
     if (threadCount > 1 || trustAllCerts) {
-      var httpClientBuilder = NettyNioAsyncHttpClient.builder().maxConcurrency(threadCount);
+      var httpClientBuilder = NettyNioAsyncHttpClient.builder()
+          .maxConcurrency(threadCount)
+          .useNonBlockingDnsResolver(false);
 
       if (trustAllCerts) {
         LOGGER.warn("Trust all certificates is enabled. This should only be used for testing with self-signed certificates. Never enable in production!");

--- a/workloads/workload_template
+++ b/workloads/workload_template
@@ -184,6 +184,13 @@ timeseries.granularity=1000
 # the following number controls the interval between retries (in seconds):
 # core_workload_insertion_retry_interval = 3
 
+# Maximum consecutive errors before a thread stops the workload.
+#
+# During the run phase, if a thread encounters this many consecutive DB errors
+# (e.g. connection failures), it will stop the entire workload to prevent
+# infinite error logging that can fill up disk. Set to 0 to disable.
+max_consecutive_errors = 10
+
 # Distributed Tracing via Apache HTrace (http://htrace.incubator.apache.org/)
 #
 # Defaults to blank / no tracing


### PR DESCRIPTION
## Summary

- `CoreWorkload.doTransaction()` always returned `true` regardless of DB errors, so connection failures on ScyllaDB and DynamoDB caused threads to spin indefinitely, logging the same error on every iteration and filling up the disk
- All five `doTransaction*` sub-methods discarded the `Status` returned by DB operations — propagate it now so errors can be observed
- Track per-thread consecutive error count; after `max_consecutive_errors` (default: `10`) consecutive failures, stop the entire workload via `requestStopBecauseOfError()`

## Changes

- **`CoreWorkload`**: changed `doTransactionRead`, `doTransactionUpdate`, `doTransactionInsert`, `doTransactionScan`, `doTransactionReadModifyWrite` from `void` → `Status`; added `max_consecutive_errors` property (default `10`, set `0` to disable)
- **`RestWorkload`**: updated overrides to match new `Status` return types
- **`workloads/workload_template`**: documented the new `max_consecutive_errors` property

## Test plan

- [ ] Run a workload against ScyllaDB and kill the node mid-run — verify workload stops after 10 consecutive errors instead of spinning
- [ ] Run a workload against DynamoDB/Alternator and block connectivity — same check
- [ ] Run a normal workload to completion — verify no regression (counter resets on success)
- [ ] Set `max_consecutive_errors=0` — verify old unlimited behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://scylladb.atlassian.net/browse/QATOOLS-143 https://scylladb.atlassian.net/browse/SCT-259